### PR TITLE
feat: add domain-specific bias manager

### DIFF
--- a/ultralytics/nn/modules/__init__.py
+++ b/ultralytics/nn/modules/__init__.py
@@ -93,6 +93,7 @@ from .transformer import (
     TransformerEncoderLayer,
     TransformerLayer,
 )
+from .domain_bias import BiasToken, DomainBiasManager
 
 __all__ = (
     "Conv",
@@ -171,5 +172,7 @@ __all__ = (
     "DownsampleConv",
     "FullPAD_Tunnel",
     "DSC3k2",
-    "DSConv"
+    "DSConv",
+    "BiasToken",
+    "DomainBiasManager",
 )

--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -1759,7 +1759,11 @@ class C3AH(nn.Module):
         self.cv3 = Conv(2 * c_, c2, 1)  
         
     def forward(self, x):
-        return self.cv3(torch.cat((self.m(self.cv1(x)), self.cv2(x)), 1))
+        out = self.cv3(torch.cat((self.m(self.cv1(x)), self.cv2(x)), 1))
+        domain = getattr(getattr(self, "model", None), "current_domain_name", "default")
+        if hasattr(getattr(self, "model", None), "domain_bias"):
+            out = self.model.domain_bias.apply(domain, "c3ah_out", out)
+        return out
 
 class FuseModule(nn.Module):
     """
@@ -1853,7 +1857,11 @@ class HyperACE(nn.Module):
         y.extend(m(y[-1]) for m in self.m)
         y[1] = out1
         y.append(out2)
-        return self.cv2(torch.cat(y, 1))
+        out = self.cv2(torch.cat(y, 1))
+        domain = getattr(getattr(self, "model", None), "current_domain_name", "default")
+        if hasattr(getattr(self, "model", None), "domain_bias"):
+            out = self.model.domain_bias.apply(domain, "hyperace_fuse", out)
+        return out
 
 class DownsampleConv(nn.Module):
     """
@@ -1889,28 +1897,23 @@ class DownsampleConv(nn.Module):
         return self.channel_adjust(self.downsample(x))
 
 class FullPAD_Tunnel(nn.Module):
-    """
-    A gated fusion module for the Full-Pipeline Aggregation-and-Distribution (FullPAD) paradigm.
+    """Gated fusion module for the FullPAD paradigm with optional domain bias."""
 
-    This module implements a gated residual connection used to fuse features. It takes two inputs: the original
-    feature map and a correlation-enhanced feature map. It then computes `output = original + gate * enhanced`,
-    where `gate` is a learnable scalar parameter that adaptively balances the contribution of the enhanced features.
+    counter = 0
 
-    Methods:
-        forward: Performs the gated fusion of two input feature maps.
-
-    Examples:
-        >>> import torch
-        >>> model = FullPAD_Tunnel()
-        >>> original_feature = torch.randn(2, 64, 32, 32)
-        >>> enhanced_feature = torch.randn(2, 64, 32, 32)
-        >>> output = model([original_feature, enhanced_feature])
-        >>> print(output.shape)
-        torch.Size([2, 64, 32, 32])
-    """
     def __init__(self):
         super().__init__()
         self.gate = nn.Parameter(torch.tensor(0.0))
+        if FullPAD_Tunnel.counter < 3:
+            self.bias_name = f"fullpad_h{FullPAD_Tunnel.counter + 3}"
+        else:
+            self.bias_name = None
+        FullPAD_Tunnel.counter += 1
+
     def forward(self, x):
-        out = x[0] + self.gate * x[1]
+        feat = x[1]
+        if self.bias_name and hasattr(getattr(self, "model", None), "domain_bias"):
+            domain = getattr(getattr(self, "model", None), "current_domain_name", "default")
+            feat = self.model.domain_bias.apply(domain, self.bias_name, feat)
+        out = x[0] + self.gate * feat
         return out

--- a/ultralytics/nn/modules/domain_bias.py
+++ b/ultralytics/nn/modules/domain_bias.py
@@ -1,0 +1,53 @@
+# Ultralytics \U0001f680 AGPL-3.0 License - https://ultralytics.com/license
+"""Domain-specific bias modules for lightweight domain bias (LDB).
+
+This module implements a BiasToken that adds learnable token and spatial weights
+as additive bias to feature maps, and a DomainBiasManager that manages sets of
+BiasTokens for different insertion points and domains.
+"""
+
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+
+class BiasToken(nn.Module):
+    """Learnable bias token and spatial weight as described in LDB."""
+
+    def __init__(self, channels: int):
+        """Initialise BiasToken with channel dimension."""
+        super().__init__()
+        self.v = nn.Parameter(torch.zeros(channels))
+        self.gamma_conv = nn.Conv2d(channels, 1, kernel_size=1)
+
+    def forward(self, feat: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        """Apply domain bias to the input feature map."""
+        gamma = torch.sigmoid(self.gamma_conv(feat))
+        v = self.v.view(1, -1, 1, 1)
+        return feat + v * gamma
+
+
+class DomainBiasManager(nn.Module):
+    """Manage BiasTokens for multiple domains and insertion points."""
+
+    def __init__(self, insertion_cfg: Dict[str, int]):
+        """Create manager with mapping of insertion names to channel counts."""
+        super().__init__()
+        self.insertion_cfg = insertion_cfg
+        self.registry = nn.ModuleDict()
+
+    def add_domain(self, domain_name: str):
+        """Register a new domain and initialise its BiasTokens."""
+        if domain_name in self.registry:
+            return
+        tokens = nn.ModuleDict({k: BiasToken(c) for k, c in self.insertion_cfg.items()})
+        self.registry[domain_name] = tokens
+
+    def apply(self, domain_name: str, insert_name: str, feat: torch.Tensor) -> torch.Tensor:
+        """Apply the BiasToken for given domain and insertion point."""
+        if domain_name not in self.registry:
+            raise KeyError(f"[DomainBias] domain {domain_name} not registered")
+        if insert_name not in self.registry[domain_name]:
+            raise KeyError(f"[DomainBias] insertion {insert_name} not registered (domain={domain_name})")
+        return self.registry[domain_name][insert_name](feat)

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -37,6 +37,7 @@ from ultralytics.nn.modules import (
     C3x,
     CBFuse,
     CBLinear,
+    C3AH,
     Classify,
     Concat,
     Conv,
@@ -69,7 +70,8 @@ from ultralytics.nn.modules import (
     HyperACE,
     DownsampleConv,
     FullPAD_Tunnel,
-    DSC3k2
+    DSC3k2,
+    DomainBiasManager,
 )
 from ultralytics.utils import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER, colorstr, emojis, yaml_load
 from ultralytics.utils.checks import check_requirements, check_suffix, check_yaml
@@ -98,19 +100,9 @@ class BaseModel(nn.Module):
     """The BaseModel class serves as a base class for all the models in the Ultralytics YOLO family."""
 
     def forward(self, x, *args, **kwargs):
-        """
-        Perform forward pass of the model for either training or inference.
-
-        If x is a dict, calculates and returns the loss for training. Otherwise, returns predictions for inference.
-
-        Args:
-            x (torch.Tensor | dict): Input tensor for inference, or dict with image tensor and labels for training.
-            *args (Any): Variable length argument list.
-            **kwargs (Any): Arbitrary keyword arguments.
-
-        Returns:
-            (torch.Tensor): Loss if x is a dict (training), or network predictions (inference).
-        """
+        """Forward pass with optional domain specification."""
+        domain = kwargs.pop("domain_name", "default")
+        setattr(self, "current_domain_name", domain)
         if isinstance(x, dict):  # for cases of training and validating while training.
             return self.loss(x, *args, **kwargs)
         return self.predict(x, *args, **kwargs)
@@ -321,6 +313,34 @@ class DetectionModel(BaseModel):
             LOGGER.info(f"Overriding model.yaml nc={self.yaml['nc']} with nc={nc}")
             self.yaml["nc"] = nc  # override YAML value
         self.model, self.save = parse_model(deepcopy(self.yaml), ch=ch, verbose=verbose)  # model, savelist
+        # attach model reference to modules for domain bias access
+        for m in self.model.modules():
+            m.model = self
+
+        # domain bias manager setup
+        insertion_cfg = {}
+        for m in self.model.modules():
+            if "c3ah_out" not in insertion_cfg and isinstance(m, C3AH):
+                insertion_cfg["c3ah_out"] = m.cv3.conv.out_channels
+            if "hyperace_fuse" not in insertion_cfg and isinstance(m, HyperACE):
+                insertion_cfg["hyperace_fuse"] = m.cv2.conv.out_channels
+        fullpad_count = 0
+        for module in self.model:
+            if isinstance(module, FullPAD_Tunnel) and fullpad_count < 3:
+                idx = module.f[0] if isinstance(module.f, (list, tuple)) else module.f
+                src = self.model[idx]
+                ch_out = None
+                if hasattr(src, "conv") and hasattr(src.conv, "out_channels"):
+                    ch_out = src.conv.out_channels
+                elif hasattr(src, "cv2") and hasattr(src.cv2, "conv"):
+                    ch_out = src.cv2.conv.out_channels
+                elif hasattr(src, "cv3") and hasattr(src.cv3, "conv"):
+                    ch_out = src.cv3.conv.out_channels
+                elif hasattr(src, "out_channels"):
+                    ch_out = src.out_channels
+                insertion_cfg[f"fullpad_h{fullpad_count + 3}"] = ch_out
+                fullpad_count += 1
+        self.domain_bias = DomainBiasManager(insertion_cfg)
         self.names = {i: f"{i}" for i in range(self.yaml["nc"])}  # default names dict
         self.inplace = self.yaml.get("inplace", True)
         self.end2end = getattr(self.model[-1], "end2end", False)


### PR DESCRIPTION
## Summary
- add BiasToken and DomainBiasManager modules
- inject domain bias into C3AH, HyperACE and early FullPAD tunnels
- expose domain selection through DetectionModel forward

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b863c663ec8321848f4df50ad9553b